### PR TITLE
Use tidy version of coords (xrobin/pROC#54)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     rmarkdown,
     curatedOvarianData,
     ROCR,
-    pROC,
+    pROC (>= 1.15.0),
     RUnit,
     simulatorZ,
     proxy

--- a/inst/TCGA_microarray_RNAseq.R
+++ b/inst/TCGA_microarray_RNAseq.R
@@ -108,7 +108,7 @@ plotROC <- function(pred, labels, plot = TRUE, na.rm = TRUE, colorize = FALSE, a
   roc.obj <- roc(labels, pred)
   auc.ci <- ci(roc.obj)
   significant <- ifelse(ci(roc.obj, conf.level=0.9)[1] > 0.5, "*", "")
-  best <- coords(roc.obj,x="best")
+  best <- coords(roc.obj,x="best", transpose = FALSE)
   if (plot) {
     plot(perf.rocr, colorize = colorize, cex.lab = 1.3, bty="n", lty=1:length(perf.rocr),...)
     abline(a = 0, b = 1, lty = 2)

--- a/inst/countdops.R
+++ b/inst/countdops.R
@@ -201,7 +201,7 @@ plotROC <- function(pred, labels, plot = TRUE, na.rm = TRUE, colorize = FALSE, .
     roc.obj <- roc(labels, pred)
     auc.ci <- ci(roc.obj)
     significant <- ifelse(ci(roc.obj, conf.level=0.9)[1] > 0.5, "*", "")
-    best <- coords(roc.obj,x="best")
+    best <- coords(roc.obj,x="best", transpose = FALSE)
     if (plot) {
         plot(perf.rocr, colorize = colorize, cex.lab = 1.3, ...)
         text(0, 0.9, paste("AUC = ", round(auc, digits = 2), significant,

--- a/vignettes/manuscript/doppelgangR.Rmd
+++ b/vignettes/manuscript/doppelgangR.Rmd
@@ -138,7 +138,7 @@ plotROC <- function(pred, labels, plot = TRUE, na.rm = TRUE, colorize = FALSE, a
     roc.obj <- roc(labels, pred)
     auc.ci <- ci(roc.obj)
     significant <- ifelse(ci(roc.obj, conf.level=0.9)[1] > 0.5, "*", "")
-    best <- coords(roc.obj,x="best")
+    best <- coords(roc.obj,x="best", transpose = FALSE)
     if (plot) {
         plot(perf.rocr, colorize = colorize, cex.lab = 1.3, bty="n", lty=1:length(perf.rocr),...)
         abline(a = 0, b = 1, lty = 2)


### PR DESCRIPTION
An upcoming version of pROC (1.16) will feature backward incompatible changes in the coords function. In order to adhere to the principles of tidy datasets, the output will be transposed, and a data.frame returned instead of a matrix.

This PR sets the 'transpose' argument to 'coords' explicitly to ensure proper operation with current (1.15) and future versions of pROC.

I couldn't find any usage of the results, it seems they are only returned invisibly and not used anywhere in the package. However please note that they are now in a data.frame, and in transposed form. Scripts that would source this function outside of the package may have to be adapted too.