### PR TITLE
Resolve BiocCheck warnings and notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ cache/
 *.swp
 *.vim
 
+.gemini/settings.json
+tests/testthat/Rplots.pdf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,5 +41,5 @@ URL: https://github.com/lwaldron/doppelgangR,
     https://waldronlab.github.io/doppelgangR
 BugReports: https://github.com/lwaldron/doppelgangR/issues
 VignetteBuilder: knitr
-RoxygenNote: 7.1.0
 Date: 2025-05-12
+Config/roxygen2/version: 8.0.0

--- a/R/DoppelGang-class.R
+++ b/R/DoppelGang-class.R
@@ -11,6 +11,7 @@
 #' @param x,object A DoppelGang class object
 #' @author Levi Waldron and Markus Riester
 #' @seealso \code{\link{plot,DoppelGang-method}}
+#' @return An object of class \code{DoppelGang}
 #' @export
 setClass(
   Class = "DoppelGang",
@@ -71,8 +72,7 @@ setMethod("print", signature(x = "DoppelGang"),
 #'
 #'
 #' @name plot-methods
-#' @aliases plot-methods plot,DoppelGang plot,DoppelGang-method
-#' plot,DoppelGang,ANY-method plot.DoppelGang plot.doppelgangR
+#' @aliases plot-methods plot,DoppelGang plot,DoppelGang-method plot,DoppelGang,ANY-method plot.DoppelGang plot.doppelgangR
 #' @docType methods
 #' @param x An object of class \code{\link{DoppelGang}}
 #' @param skip.no.doppels (default FALSE) If TRUE, do not plot histograms where

--- a/R/colFinder.R
+++ b/R/colFinder.R
@@ -29,8 +29,8 @@
 #'
 #' @examples
 #' library(SummarizedExperiment)
-#' summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=DataFrame(a=1:2))
-#' summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=DataFrame(a=1:2))
+#' summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=S4Vectors::DataFrame(a=1:2))
+#' summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=S4Vectors::DataFrame(a=1:2))
 #' colFinder(list(summex1, summex2))
 #'
 #' @export colFinder

--- a/R/colFinder.R
+++ b/R/colFinder.R
@@ -27,6 +27,12 @@
 #' @return A matrix of similarities between the colData of pairs of samples.
 #' @author Fabio Da Col, Marcel Ramos
 #'
+#' @examples
+#' library(SummarizedExperiment)
+#' summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=DataFrame(a=1:2))
+#' summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=DataFrame(a=1:2))
+#' colFinder(list(summex1, summex2))
+#'
 #' @export colFinder
 colFinder <- function(summex.list, ...) {
     if (!is(summex.list, "list") | length(summex.list) != 2)

--- a/R/doppelgangR-package.R
+++ b/R/doppelgangR-package.R
@@ -7,8 +7,7 @@
 #' data (pData(eset)), and "smoking guns" - supposedly unique identifiers found
 #' in pData(eset).
 #'
-#' @importFrom Biobase exprs featureNames sampleNames pData "sampleNames<-"
-#' "exprs<-" "pData<-"
+#' @importFrom Biobase exprs featureNames sampleNames pData "sampleNames<-" "exprs<-" "pData<-"
 #' @importFrom BiocParallel bplapply bpparam
 #' @importFrom sva ComBat
 #' @importFrom digest digest
@@ -17,12 +16,7 @@
 #' @import methods
 #' @importFrom grDevices dev.interactive
 #' @importFrom graphics abline contour curve hist legend lines pairs par points title
-#' @importFrom stats coef complete.cases cor cov2cor
-#'           dchisq dnorm dt integrate lm.fit
-#'           model.matrix na.omit nlminb optim pchisq
-#'           pf pnorm pt qchisq qf qnorm rchisq
-#'           resid rnorm runif uniroot var
-#'           weighted.mean
+#' @importFrom stats coef complete.cases cor cov2cor dchisq dnorm dt integrate lm.fit model.matrix na.omit nlminb optim pchisq pf pnorm pt qchisq qf qnorm rchisq resid rnorm runif uniroot var weighted.mean
 #' @importFrom utils combn
 #' @importFrom SummarizedExperiment assay colData
 #'

--- a/R/doppelgangR.R
+++ b/R/doppelgangR.R
@@ -59,14 +59,12 @@
 #'
 #' ## Set phenoFinder.args=NULL to ignore similar phenotypes, and
 #' ## turn off ComBat batch correction:
-#'
-#' \dontrun{
+#' if (require("curatedOvarianData", quietly = TRUE)) {
 #' results2 <- doppelgangR(testesets,
 #' corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
 #'     cache.dir=NULL)
 #' summary(results2)
 #'
-#' library(curatedOvarianData)
 #' data(GSE32062.GPL6480_eset)
 #' data(GSE32063_eset)
 #' data(GSE12470_eset)

--- a/R/doppelgangR.R
+++ b/R/doppelgangR.R
@@ -60,11 +60,6 @@
 #' ## Set phenoFinder.args=NULL to ignore similar phenotypes, and
 #' ## turn off ComBat batch correction:
 #' if (require("curatedOvarianData", quietly = TRUE)) {
-#' results2 <- doppelgangR(testesets,
-#' corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
-#'     cache.dir=NULL)
-#' summary(results2)
-#'
 #' data(GSE32062.GPL6480_eset)
 #' data(GSE32063_eset)
 #' data(GSE12470_eset)
@@ -90,6 +85,12 @@
 #' plot(results1)
 #' summary(results1)
 #'
+#' ## Set phenoFinder.args=NULL to ignore similar phenotypes, and
+#' ## turn off ComBat batch correction:
+#' results2 <- doppelgangR(testesets,
+#' corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
+#'     cache.dir=NULL)
+#' summary(results2)
 #' }
 #'
 #' @export doppelgangR

--- a/R/nonexports.R
+++ b/R/nonexports.R
@@ -2136,7 +2136,7 @@ mst.dev <-
       L. <- L * sqrt((1 + d / df) / (1 + Q / df))
     }
     dev <- (n * (logDet - 2 * const + d * logb(pi)) + DQ
-            - 2 * sum(freq * (log(2) + log.pt(L., df + d))))
+            - 2 * sum(freq * (log(2) + log_pt(L., df + d))))
     if (trace)
       cat("mst.dev: ", dev, "\n")
     dev
@@ -2179,7 +2179,7 @@ mst.dev.grad <-
     dlogft <- (-0.5) * (1 + d / df) / (1 + Q / df)
     dt.dL <- sf
     dt.dQ <- (-0.5) * L * sf / (Q + df)
-    logT. <- log.pt(t., df + d)
+    logT. <- log_pt(t., df + d)
     dlogT. <- exp(dt(t., df + d, log = TRUE) - logT.)
     u.freq <- u * freq
     Dbeta <- (
@@ -2227,7 +2227,7 @@ mst.dev.grad <-
           sqrt((df1 + d) / (Q + df1))
       else
         sqrt((1 + d / df1) / (1 + Q / df1))
-      logT.eps <- log.pt(L * sf1, df1 + d)
+      logT.eps <- log_pt(L * sf1, df1 + d)
       dlogT.ddf <- (logT.eps - logT.) / eps
       Ddf   <- sum((dlogft.ddf + dlogT.ddf) * freq)
       grad <- c(grad, -2 * Ddf * df0)
@@ -2421,7 +2421,7 @@ st.dev.fixed <- function(free.param,
   }
   dev <-
     (n * (logDet - 2 * const + logb(pi)) + (df + 1) * sum(freq * log1Q)
-     - 2 * sum(log(2) + log.pt(L * sqrt((
+     - 2 * sum(log(2) + log_pt(L * sqrt((
        df + 1
      ) / (
        Q + df
@@ -2902,7 +2902,7 @@ solvePD <- function(x)
 
 
 ##---
-log.pt <- function(x, df) {
+log_pt <- function(x, df) {
   ## fix for log(pt(...)) when it gives -Inf
   ## see Abramowitz & Stegun formulae 26.7.8 & 26.2.13)
   ## However, new releases of R (>=2.3) seem to have fixed the problem

--- a/R/phenoDist.R
+++ b/R/phenoDist.R
@@ -27,9 +27,7 @@
 #' distmat <- phenoDist(as.matrix(pdat1), as.matrix(pdat2))
 #' ## Note outliers with identical clinical data, these are probably the same patients:
 #' graphics::boxplot(distmat)
-#'
-#' \dontrun{
-#'    library(curatedOvarianData)
+#' if (require("curatedOvarianData", quietly = TRUE)) {
 #'    data(GSE32063_eset)
 #'    data(GSE17260_eset)
 #'    pdat1 <- pData(GSE32063_eset)

--- a/man/DoppelGang-class.Rd
+++ b/man/DoppelGang-class.Rd
@@ -18,6 +18,9 @@
 \arguments{
 \item{x, object}{A DoppelGang class object}
 }
+\value{
+An object of class \code{DoppelGang}
+}
 \description{
 S4 class containing results of doppelgangR() function.
 }

--- a/man/colFinder.Rd
+++ b/man/colFinder.Rd
@@ -25,8 +25,8 @@ different DataFrame
 }
 \examples{
 library(SummarizedExperiment)
-summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=DataFrame(a=1:2))
-summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=DataFrame(a=1:2))
+summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=S4Vectors::DataFrame(a=1:2))
+summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=S4Vectors::DataFrame(a=1:2))
 colFinder(list(summex1, summex2))
 
 }

--- a/man/colFinder.Rd
+++ b/man/colFinder.Rd
@@ -23,6 +23,13 @@ This function acts as a wrapper to colData to handle cases of one
 DataFrame, a list of two identical DataFrame, or a list of two
 different DataFrame
 }
+\examples{
+library(SummarizedExperiment)
+summex1 <- SummarizedExperiment(matrix(1:4, ncol=2), colData=DataFrame(a=1:2))
+summex2 <- SummarizedExperiment(matrix(5:8, ncol=2), colData=DataFrame(a=1:2))
+colFinder(list(summex1, summex2))
+
+}
 \author{
 Fabio Da Col, Marcel Ramos
 }

--- a/man/doppelgangR-package.Rd
+++ b/man/doppelgangR-package.Rd
@@ -15,6 +15,7 @@ in pData(eset).
 Useful links:
 \itemize{
   \item \url{https://github.com/lwaldron/doppelgangR}
+  \item \url{https://waldronlab.github.io/doppelgangR}
   \item Report bugs at \url{https://github.com/lwaldron/doppelgangR/issues}
 }
 

--- a/man/doppelgangR.Rd
+++ b/man/doppelgangR.Rd
@@ -95,11 +95,6 @@ summary(results2)
 ## Set phenoFinder.args=NULL to ignore similar phenotypes, and
 ## turn off ComBat batch correction:
 if (require("curatedOvarianData", quietly = TRUE)) {
-results2 <- doppelgangR(testesets,
-corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
-    cache.dir=NULL)
-summary(results2)
-
 data(GSE32062.GPL6480_eset)
 data(GSE32063_eset)
 data(GSE12470_eset)
@@ -125,6 +120,12 @@ testesets <- lapply(testesets, function(X) {
 plot(results1)
 summary(results1)
 
+## Set phenoFinder.args=NULL to ignore similar phenotypes, and
+## turn off ComBat batch correction:
+results2 <- doppelgangR(testesets,
+corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
+    cache.dir=NULL)
+summary(results2)
 }
 
 }

--- a/man/doppelgangR.Rd
+++ b/man/doppelgangR.Rd
@@ -94,14 +94,12 @@ summary(results2)
 
 ## Set phenoFinder.args=NULL to ignore similar phenotypes, and
 ## turn off ComBat batch correction:
-
-\dontrun{
+if (require("curatedOvarianData", quietly = TRUE)) {
 results2 <- doppelgangR(testesets,
 corFinder.args=list(use.ComBat=FALSE), phenoFinder.args=NULL,
     cache.dir=NULL)
 summary(results2)
 
-library(curatedOvarianData)
 data(GSE32062.GPL6480_eset)
 data(GSE32063_eset)
 data(GSE12470_eset)

--- a/man/phenoDist.Rd
+++ b/man/phenoDist.Rd
@@ -40,9 +40,7 @@ pdat2 <- pData(esets2[[2]])
 distmat <- phenoDist(as.matrix(pdat1), as.matrix(pdat2))
 ## Note outliers with identical clinical data, these are probably the same patients:
 graphics::boxplot(distmat)
-
-\dontrun{
-   library(curatedOvarianData)
+if (require("curatedOvarianData", quietly = TRUE)) {
    data(GSE32063_eset)
    data(GSE17260_eset)
    pdat1 <- pData(GSE32063_eset)

--- a/vignettes/doppelgangR.Rmd
+++ b/vignettes/doppelgangR.Rmd
@@ -24,9 +24,11 @@ output:
   toc: true
 ---
 
-```{r, echo=FALSE, results='hide', eval=FALSE}
+```{r setup, echo=FALSE, results='hide', message=FALSE}
 library(knitr)
 opts_knit$set(cache=TRUE)
+has_data <- requireNamespace("curatedOvarianData", quietly = TRUE)
+opts_chunk$set(eval = has_data)
 ```
 
 # doppelgängR
@@ -47,7 +49,7 @@ Results from running `doppelgangR` on CRC, bladder, and ovarian
 For the manuscript vignette, visit
 <https://github.com/waldronlab/doppelgangR_paper>.
 
-```{r, echo=FALSE, message=FALSE}
+```{r loadpkg, echo=FALSE, message=FALSE}
 library(doppelgangR)
 ```
 
@@ -90,7 +92,7 @@ profiled by microarray and RNA-seq.
 We load for datasets by Yoshihara __et al.__ that have been curated
 in `r BiocStyle::Biocexptpkg("curatedOvarianData")`.  These are objects of class `ExpressionSet`.
 
-```{r, message = FALSE}
+```{r loaddata, message = FALSE}
 library(curatedOvarianData)
 data(GSE32062.GPL6480_eset)
 data(GSE17260_eset)
@@ -147,7 +149,7 @@ If after inspecting the histograms, you see that some visible outliers were not
 caught, or non-outliers exceeded the sensitivity threshold, you can change the
 default sensitivity using the argument:
 
-```{r, eval=FALSE}
+```{r changesens, eval=FALSE}
 outlierFinder.expr.args =
     list(bonf.prob = 0.5, transFun = atanh, tail = "upper")
 ```
@@ -169,7 +171,7 @@ The `doppelgangR()` function takes as its main argument a list of
 `ExpressionSet` objects.  If you just have matrices, you can easily convert
 these to the `ExpressionSet` objects, for example:
 
-```{r}
+```{r makematrix}
 mat <- matrix(1:4, ncol=2)
 library(Biobase)
 eset <- ExpressionSet(mat)
@@ -184,7 +186,7 @@ parallel using multiple processing cores using the BPPARAM argument. This
 functionality is imported from the \Biocpkg("BiocParallel") package. Please see
 "?BiocParallel::\`BiocParallelParam-class\`" documentation. 
 
-```{r, eval=FALSE}
+```{r parallel, eval=FALSE}
 results2 <- doppelgangR(testesets, BPPARAM = MulticoreParam(workers = 8))
 ```
 
@@ -193,3 +195,9 @@ results2 <- doppelgangR(testesets, BPPARAM = MulticoreParam(workers = 8))
 By default, the `doppelgangR()` function caches intermediate results to make
 re-running with different arguments faster.  Turn caching off by setting the
 argument `cache.dir=NULL`.
+
+# Session Info
+
+```{r sessionInfo, eval=TRUE}
+sessionInfo()
+```


### PR DESCRIPTION
Resolves BiocCheck warnings and notes, specifically making examples runnable and fixing roxygen2 formatting. Co-authored-by: Antigravity <gemini@google.com>